### PR TITLE
set v6_only explicitly.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,6 @@ log = "0.4"
 
 [dev-dependencies]
 mio = "0.6"
+net2 = "0.2"
 env_logger = "0.7.1"
 docopt = "1"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -7,6 +7,7 @@ extern crate env_logger;
 use env_logger::Target;
 use mio::net::UdpSocket;
 use mio::{Events, Poll, PollOpt, Ready, Token};
+use net2::UdpBuilder;
 use std::net::{IpAddr, SocketAddr};
 
 use rusctp::*;
@@ -57,7 +58,9 @@ fn main() {
     let udpsock4 = std::net::UdpSocket::bind("0.0.0.0:0").unwrap();
     let udpsock4 = UdpSocket::from_socket(udpsock4).unwrap();
 
-    let udpsock6 = std::net::UdpSocket::bind(":::0").unwrap();
+    let udp6_builder = UdpBuilder::new_v6().unwrap();
+    udp6_builder.only_v6(true).unwrap();
+    let udpsock6 = udp6_builder.bind(":::0").unwrap();
     let udpsock6 = UdpSocket::from_socket(udpsock6).unwrap();
 
     let mut assoc = SctpAssociation::connect(

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -5,6 +5,7 @@ extern crate env_logger;
 
 use mio::net::UdpSocket;
 use mio::{Events, Poll, PollOpt, Ready, Token};
+use net2::UdpBuilder;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
@@ -64,7 +65,10 @@ fn main() {
         IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
         server_udp_port,
     )];
-    let udpsock6 = std::net::UdpSocket::bind(&addrs[..]).unwrap();
+    //let udpsock6 = std::net::UdpSocket::bind(&addrs[..]).unwrap();
+    let udp6_builder = UdpBuilder::new_v6().unwrap();
+    udp6_builder.only_v6(true).unwrap();
+    let udpsock6 = udp6_builder.bind(&addrs[..]).unwrap();
     let udpsock6 = UdpSocket::from_socket(udpsock6).unwrap();
 
     poll.register(&udpsock4, Token(0), Ready::readable(), PollOpt::edge())


### PR DESCRIPTION
A socket binding to Any IPv6 address socket may bound to any IPv4 address (Typically, on Linux). So, we should set v6_only explicitly.