### PR TITLE
fix for sending the Shuwdown-Complete

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -164,6 +164,10 @@ fn main() {
                             match assoc.recv(&from.ip(), &rbuf[off..len], &mut sbuf) {
                                 Ok(v) => {
                                     off += v;
+                                    if assoc.is_closed() {
+                                        rip = Some(from.ip());
+                                    }    
+                        
                                 }
                                 Err(e) => {
                                     error!("SctpAssociation::recv() failed: {:?}", e);
@@ -198,6 +202,7 @@ fn main() {
                 }
             }
             if assoc.get_pending().count() == 0 {
+                info!("Close Association");
                 assoc.close().unwrap();
             }
         }
@@ -216,11 +221,11 @@ fn main() {
                 }
             }
         }
-        if assoc.is_closed() {
-            break 'main;
-        }
-
         if sbuf.is_empty() {
+            if assoc.is_closed() {
+                info!("Association closed");
+                break 'main;
+            }    
             'send: loop {
                 match assoc.send(&mut sbuf) {
                     Ok((_, rip1)) => {

--- a/src/sctp_recovery.rs
+++ b/src/sctp_recovery.rs
@@ -975,14 +975,6 @@ impl SctpRecovery {
 
     pub fn on_shutdown_ack_received(&mut self) {
         self.t2_shutdown_timeout = None;
-        // Send Shutdown-Complete
-        let shutdown_complete = SctpChunk::ShutdownComplete(false);
-        trace!("{} send SHUTDONW-COMPLETION", self.trace_id);
-        self.control_waiting_trans.insert(
-            self.next_control_sequence.0,
-            (shutdown_complete, self.primary_path.unwrap_or(0)),
-        );
-        self.next_control_sequence += 1;
     }
 }
 


### PR DESCRIPTION
We cannot send the Shutdown-Complete via Association. We should store it immediately after recv().